### PR TITLE
Add void* arg support to wiring PI (as external code not integrated)…

### DIFF
--- a/src/4SegLedTwoButtonsBlockDetectionPrototype/BlockDetector.vcxproj
+++ b/src/4SegLedTwoButtonsBlockDetectionPrototype/BlockDetector.vcxproj
@@ -51,7 +51,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Link>
-      <LibraryDependencies>wiringPi</LibraryDependencies>
+      <LibraryDependencies>wiringPi;pthread</LibraryDependencies>
     </Link>
     <RemotePostBuildEvent>
       <Command>gpio export 17 out &amp;&amp; gpio export 18 out &amp;&amp; gpio export 27 out &amp;&amp; gpio export 22 out &amp;&amp; gpio export 23 out &amp;&amp; gpio export 24 out &amp;&amp; gpio export 25 out &amp;&amp; gpio export 2 out &amp;&amp; gpio export 3 out &amp;&amp; gpio export 4 out &amp;&amp; gpio export 8 out &amp;&amp; gpio export 7 out  &amp;&amp; gpio export 7 out  &amp;&amp; gpio export 7 out &amp;&amp; gpio export 19 out &amp;&amp; gpio export 26 out &amp;&amp; gpio export 27 in &amp;&amp; gpio export 28 in</Command>
@@ -71,10 +71,12 @@
     <ClCompile Include="AxleCounter.cpp" />
     <ClCompile Include="Display.cpp" />
     <ClCompile Include="Main.cpp" />
+    <ClCompile Include="WiringPiExt.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Headers\AxleCounter.h" />
     <ClInclude Include="Headers\Display.h" />
+    <ClInclude Include="Headers\WiringPiExt.h" />
   </ItemGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>

--- a/src/4SegLedTwoButtonsBlockDetectionPrototype/BlockDetector.vcxproj.filters
+++ b/src/4SegLedTwoButtonsBlockDetectionPrototype/BlockDetector.vcxproj.filters
@@ -3,6 +3,8 @@
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="AxleCounter.cpp" />
+    <ClCompile Include="Display.cpp" />
+    <ClCompile Include="WiringPiExt.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Headers">
@@ -14,6 +16,9 @@
       <Filter>Headers</Filter>
     </ClInclude>
     <ClInclude Include="Headers\AxleCounter.h">
+      <Filter>Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Headers\WiringPiExt.h">
       <Filter>Headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/4SegLedTwoButtonsBlockDetectionPrototype/Display.cpp
+++ b/src/4SegLedTwoButtonsBlockDetectionPrototype/Display.cpp
@@ -5,10 +5,7 @@
 
 
 // Contains the code to actual the pins for the four digit 7 segment display.
-unsigned char const SegCode[10] = { 0x3f,0x06,0x5b,0x4f,0x66,0x6d,0x7d,0x07,0x7f,0x6f };
-
-// the segcode to display for each digit.
-unsigned char DatBuf[4] = { 0,0,0,0 };
+unsigned char const FourDigitSevenSegmentDisplay::SegCode[10] = { 0x3f,0x06,0x5b,0x4f,0x66,0x6d,0x7d,0x07,0x7f,0x6f };
 
 FourDigitSevenSegmentDisplay::FourDigitSevenSegmentDisplay(int pin0, int pin1, int pin2, int pin3)
 {
@@ -40,10 +37,10 @@ void FourDigitSevenSegmentDisplay::SysInit(void)
 
 void FourDigitSevenSegmentDisplay::SetDisplayValue(int value)
 {
-	DatBuf[0] = SegCode[value % 10];
-	DatBuf[1] = SegCode[value % 100 / 10];
-	DatBuf[2] = SegCode[value % 1000 / 100];
-	DatBuf[3] = SegCode[value / 1000];
+	_datBuf[0] = SegCode[value % 10];
+	_datBuf[1] = SegCode[value % 100 / 10];
+	_datBuf[2] = SegCode[value % 1000 / 100];
+	_datBuf[3] = SegCode[value / 1000];
 }
 
 void FourDigitSevenSegmentDisplay::Display(void)
@@ -55,7 +52,7 @@ void FourDigitSevenSegmentDisplay::Display(void)
 		digitalWrite(_pin1, 1);
 		digitalWrite(_pin2, 1);
 		digitalWrite(_pin3, 1);
-		digitalWriteByte(DatBuf[0]);
+		digitalWriteByte(_datBuf[0]);
 
 		delay(1);
 
@@ -63,7 +60,7 @@ void FourDigitSevenSegmentDisplay::Display(void)
 		digitalWrite(_pin1, 0);
 		digitalWrite(_pin2, 1);
 		digitalWrite(_pin3, 1);
-		digitalWriteByte(DatBuf[1]);
+		digitalWriteByte(_datBuf[1]);
 
 		delay(1);
 
@@ -71,7 +68,7 @@ void FourDigitSevenSegmentDisplay::Display(void)
 		digitalWrite(_pin1, 1);
 		digitalWrite(_pin2, 0);
 		digitalWrite(_pin3, 1);
-		digitalWriteByte(DatBuf[2]);
+		digitalWriteByte(_datBuf[2]);
 
 		delay(1);
 
@@ -79,7 +76,7 @@ void FourDigitSevenSegmentDisplay::Display(void)
 		digitalWrite(_pin1, 1);
 		digitalWrite(_pin2, 1);
 		digitalWrite(_pin3, 0);
-		digitalWriteByte(DatBuf[3]);
+		digitalWriteByte(_datBuf[3]);
 
 		delay(1);
 	}

--- a/src/4SegLedTwoButtonsBlockDetectionPrototype/Headers/AxleCounter.h
+++ b/src/4SegLedTwoButtonsBlockDetectionPrototype/Headers/AxleCounter.h
@@ -10,15 +10,8 @@ private:
 	int _leftOutputState;
 	int _rightOutputState;
 
-	static const int maxAxleCounter = 1;
-	static int _actualAxleCoutners;
-
-	static AxleCounter* AxleCounters[maxAxleCounter];
-
-	static void LeftRailIsr0();
-	static void RightRailIsr0();
-
-	static void(*isrFunctions[2 * maxAxleCounter])(void);
+	static void LeftRailIsr0(void* arg);
+	static void RightRailIsr0(void* arg);
 
 	void LeftRailISR();
 	void RightRailISR();

--- a/src/4SegLedTwoButtonsBlockDetectionPrototype/Headers/Display.h
+++ b/src/4SegLedTwoButtonsBlockDetectionPrototype/Headers/Display.h
@@ -7,6 +7,10 @@ private:
 	int _pin1;
 	int _pin2;
 	int _pin3;
+	
+	unsigned char _datBuf[4] = { 0,0,0,0 };
+
+	static unsigned char const SegCode[10];
 
 public:
 	FourDigitSevenSegmentDisplay(int pin0, int pin1, int pin2, int pin3);

--- a/src/4SegLedTwoButtonsBlockDetectionPrototype/Headers/WiringPiExt.h
+++ b/src/4SegLedTwoButtonsBlockDetectionPrototype/Headers/WiringPiExt.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern int  wiringPiISRExt(int pin, int mode, void(*function)(void*), void* arg);

--- a/src/4SegLedTwoButtonsBlockDetectionPrototype/Main.cpp
+++ b/src/4SegLedTwoButtonsBlockDetectionPrototype/Main.cpp
@@ -38,7 +38,13 @@ void sysInit(void)
 
 int main(void)
 {
-	if(wiringPiSetup() == -1){ //when initialize wiring failed,print message to screen
+
+	// Important: currently the interrupt extensions made for
+	// this project ONLY work in WPI_MODE_PINS mode...
+	if(wiringPiSetup() == -1)
+	{
+
+		// when initialize wiring failed,print message to screen
 		printf("setup wiringPi failed !\n");
 		return -1; 
 	}

--- a/src/4SegLedTwoButtonsBlockDetectionPrototype/WiringPiExt.cpp
+++ b/src/4SegLedTwoButtonsBlockDetectionPrototype/WiringPiExt.cpp
@@ -1,0 +1,178 @@
+#include <WiringPiExt.h>
+
+#include <wiringPi.h>
+
+#include <unistd.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <poll.h>
+#include <errno.h>
+#include <string.h>
+#include<sys/types.h>
+#include<sys/wait.h>
+#include <sys/ioctl.h>
+#include <asm/ioctl.h>
+#include <fcntl.h>
+
+extern int wiringPiMode;
+extern int *pinToGpio;
+extern int *physToGpio;
+
+
+static int sysFds[64] =
+{
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+};
+pthread_mutex_t pinMutex;
+int pinPass;
+
+static void(*isrFunctionsExt[64])(void*);
+
+int waitForInterruptExt(int bcmPin, int mS)
+{
+	int fd, x;
+	uint8_t c;
+	struct pollfd polls;
+
+	/**/ /*if (wiringPiMode == WPI_MODE_PINS)
+		pin = pinToGpio[pin];
+	else if (wiringPiMode == WPI_MODE_PHYS)
+		pin = physToGpio[pin];*/
+
+	if ((fd = sysFds[bcmPin]) == -1)
+		return -2;
+
+	// Setup poll structure
+
+	polls.fd = fd;
+	polls.events = POLLPRI | POLLERR;
+
+	// Wait for it ...
+
+	x = poll(&polls, 1, mS);
+
+	// If no error, do a dummy read to clear the interrupt
+	//	A one character read appars to be enough.
+
+	if (x > 0)
+	{
+		lseek(fd, 0, SEEK_SET);	// Rewind
+		(void)read(fd, &c, 1);	// Read & clear
+	}
+
+	return x;
+}
+
+void* interruptHandlerExt(UNU void *arg)
+{
+	int myPin;
+
+	(void)piHiPri(55);	// Only effective if we run as root
+
+	myPin = pinPass;
+	pinPass = -1;
+
+	for (;;)
+	{
+		int result = waitForInterruptExt(myPin, -1);
+		if (result > 0)
+			isrFunctionsExt[myPin](arg);
+	}
+
+	return NULL;
+}
+
+int wiringPiISRExt(int pin, int mode, void(*function)(void*), void* arg)
+{
+	pthread_t threadId;
+	const char *modeS;
+	char fName[64];
+	char  pinS[8];
+	pid_t pid;
+	int   count, i;
+	char  c;
+	int   bcmGpioPin;
+
+	if ((pin < 0) || (pin > 63))
+		return wiringPiFailure(WPI_FATAL, "wiringPiISR: pin must be 0-63 (%d)\n", pin);
+
+	///**/ if (wiringPiMode == WPI_MODE_UNINITIALISED)
+	//	return wiringPiFailure(WPI_FATAL, "wiringPiISR: wiringPi has not been initialised. Unable to continue.\n");
+	//else if (wiringPiMode == WPI_MODE_PINS)
+	bcmGpioPin = wpiPinToGpio(pin);
+	//else if (wiringPiMode == WPI_MODE_PHYS)
+	//	bcmGpioPin = physToGpio[pin];
+	//else
+	//bcmGpioPin = pin;
+
+	// Now export the pin and set the right edge
+	//	We're going to use the gpio program to do this, so it assumes
+	//	a full installation of wiringPi. It's a bit 'clunky', but it
+	//	is a way that will work when we're running in "Sys" mode, as
+	//	a non-root user. (without sudo)
+
+	if (mode != INT_EDGE_SETUP)
+	{
+		/**/ if (mode == INT_EDGE_FALLING)
+			modeS = "falling";
+		else if (mode == INT_EDGE_RISING)
+			modeS = "rising";
+		else
+			modeS = "both";
+
+		sprintf(pinS, "%d", bcmGpioPin);
+
+		if ((pid = fork()) < 0)	// Fail
+			return wiringPiFailure(WPI_FATAL, "wiringPiISR: fork failed: %s\n", strerror(errno));
+
+		if (pid == 0)	// Child, exec
+		{
+			/**/ if (access("/usr/local/bin/gpio", X_OK) == 0)
+			{
+				execl("/usr/local/bin/gpio", "gpio", "edge", pinS, modeS, (char *)NULL);
+				return wiringPiFailure(WPI_FATAL, "wiringPiISR: execl failed: %s\n", strerror(errno));
+			}
+			else if (access("/usr/bin/gpio", X_OK) == 0)
+			{
+				execl("/usr/bin/gpio", "gpio", "edge", pinS, modeS, (char *)NULL);
+				return wiringPiFailure(WPI_FATAL, "wiringPiISR: execl failed: %s\n", strerror(errno));
+			}
+			else
+				return wiringPiFailure(WPI_FATAL, "wiringPiISR: Can't find gpio program\n");
+		}
+		else		// Parent, wait
+			wait(NULL);
+
+		// Now pre-open the /sys/class node - but it may already be open if
+//	we are in Sys mode...
+
+		if (sysFds[bcmGpioPin] == -1)
+		{
+			sprintf(fName, "/sys/class/gpio/gpio%d/value", bcmGpioPin);
+			if ((sysFds[bcmGpioPin] = open(fName, O_RDWR)) < 0)
+				return wiringPiFailure(WPI_FATAL, "wiringPiISR: unable to open %s: %s\n", fName, strerror(errno));
+		}
+
+		// Clear any initial pending interrupt
+
+		ioctl(sysFds[bcmGpioPin], FIONREAD, &count);
+		for (i = 0; i < count; ++i)
+			read(sysFds[bcmGpioPin], &c, 1);
+
+		isrFunctionsExt[bcmGpioPin] = function;
+
+		pthread_mutex_lock(&pinMutex);
+		pinPass = bcmGpioPin;
+		pthread_create(&threadId, NULL, interruptHandlerExt, arg);
+		while (pinPass != -1)
+			delay(1);
+		pthread_mutex_unlock(&pinMutex);
+	}
+
+		return 0;
+}


### PR DESCRIPTION
… so installed wiringPi is still used.

Refactor axle counter to pass this as the arg to interrupt routines.
Refactor LED display code.